### PR TITLE
Threading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby '1.9.3', engine: 'rbx', engine_version: '2.0.0.rc1'
 
 gem 'sinatra', '~> 1.4.2'
 gem 'puma', '~> 2.0.1'
+gem 'rake', '~> 10.0.4'
 
 gem 'activesupport', '~> 3.2.13'
 gem 'data_mapper', '~> 1.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,5 +111,5 @@ DEPENDENCIES
   maruku (~> 0.6.1)
   newrelic_rpm
   puma (~> 2.0.1)
-  rake
+  rake (~> 10.0.4)
   sinatra (~> 1.4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     rack (1.5.2)
     rack-protection (1.5.0)
       rack
+    rake (10.0.4)
     sinatra (1.4.2)
       rack (~> 1.5, >= 1.5.2)
       rack-protection (~> 1.4)
@@ -110,4 +111,5 @@ DEPENDENCIES
   maruku (~> 0.6.1)
   newrelic_rpm
   puma (~> 2.0.1)
+  rake
   sinatra (~> 1.4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,5 +111,5 @@ DEPENDENCIES
   maruku (~> 0.6.1)
   newrelic_rpm
   puma (~> 2.0.1)
-  rake (~> 10.0.4)
+  rake
   sinatra (~> 1.4.2)

--- a/Rakefile
+++ b/Rakefile
@@ -3,5 +3,6 @@ $:.unshift File.dirname(__FILE__)
 desc "Remove old characters"
 task :clean do
   require 'character'
+  Character.dm_setup
   Character.all(:updated_at.lt => 1.week.ago).each { |c| c.destroy }
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+$:.unshift File.dirname(__FILE__)
+
+desc "Remove old characters"
+task :clean do
+  require 'character'
+  Character.all(:updated_at.lt => 1.week.ago).each { |c| c.destroy }
+end

--- a/character.rb
+++ b/character.rb
@@ -28,7 +28,6 @@ class Character
 
   include DataMapper::Resource
 
-  before :create, :cleanup
   before :create, :titleize
 
   property :id,         Serial
@@ -64,10 +63,6 @@ class Character
   end
 
 private
-  def cleanup
-    Character.all(:updated_at.lt => 1.week.ago).each { |c| c.destroy } if Character.count > 9000
-  end
-
   def titleize
     self.region = region.downcase
     self.realm  = realm.titleize

--- a/character.rb
+++ b/character.rb
@@ -57,11 +57,7 @@ class Character
     return unless updated_at < 3.hours.ago or not img_s3.exists?
 
     json = JSON.parse(Net::HTTP.get(api_uri))
-    if json["status"] != "ok"
-      msg = "API status not ok for #{char_path}"
-      msg += ": " + json["msg"] if json["msg"]
-      raise APINotOkError, msg
-    end
+    raise APINotOkError, json["msg"] unless json["status"] == "ok"
 
     img_s3.write(Net::HTTP.get URI(json["link"]))
     self.update updated_at: Time.now

--- a/character.rb
+++ b/character.rb
@@ -4,6 +4,10 @@ require 'data_mapper'
 require 'net/http'
 require 'json'
 
+DataMapper::Model.raise_on_save_failure = true
+DataMapper.setup(:default, (ENV["DATABASE_URL"] || "sqlite3:///#{Dir.pwd}/development.sqlite3"))
+DataMapper.auto_upgrade!
+
 class APINotOkError < StandardError
 end
 
@@ -17,12 +21,6 @@ class Character
         access_key_id:     ENV["AWS_ACCESS_KEY_ID"],
         secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"]).buckets[bucket_name]
       @@bucket
-    end
-
-    def dm_setup
-      DataMapper::Model.raise_on_save_failure = true
-      DataMapper.setup(:default, (ENV["DATABASE_URL"] || "sqlite3:///#{Dir.pwd}/development.sqlite3"))
-      DataMapper.auto_upgrade!
     end
   end
 

--- a/character.rb
+++ b/character.rb
@@ -4,10 +4,6 @@ require 'data_mapper'
 require 'net/http'
 require 'json'
 
-DataMapper::Model.raise_on_save_failure = true
-DataMapper.setup(:default, (ENV["DATABASE_URL"] || "sqlite3:///#{Dir.pwd}/development.sqlite3"))
-DataMapper.auto_upgrade!
-
 class APINotOkError < StandardError
 end
 
@@ -21,6 +17,12 @@ class Character
         access_key_id:     ENV["AWS_ACCESS_KEY_ID"],
         secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"]).buckets[bucket_name]
       @@bucket
+    end
+
+    def dm_setup
+      DataMapper::Model.raise_on_save_failure = true
+      DataMapper.setup(:default, (ENV["DATABASE_URL"] || "sqlite3:///#{Dir.pwd}/development.sqlite3"))
+      DataMapper.auto_upgrade!
     end
   end
 

--- a/character.rb
+++ b/character.rb
@@ -1,4 +1,6 @@
 require 'active_support/core_ext'
+require 'aws/s3'
+require 'data_mapper'
 require 'net/http'
 require 'json'
 
@@ -6,6 +8,18 @@ class APINotOkError < StandardError
 end
 
 class Character
+  class << self
+    def bucket
+      bucket_name = "bestsigs-wow-cacher"
+      bucket_name += "-development" if ENV["RACK_ENV"] == "development"
+
+      @@bucket ||= AWS::S3.new(
+        access_key_id:     ENV["AWS_ACCESS_KEY_ID"],
+        secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"]).buckets[bucket_name]
+      @@bucket
+    end
+  end
+
   include DataMapper::Resource
 
   before :create, :cleanup
@@ -71,6 +85,6 @@ private
   end
 
   def img_s3
-    $bucket.objects["#{char_path}.png"]
+    Character.bucket.objects["#{char_path}.png"]
   end
 end

--- a/character.rb
+++ b/character.rb
@@ -18,6 +18,12 @@ class Character
         secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"]).buckets[bucket_name]
       @@bucket
     end
+
+    def dm_setup
+      DataMapper::Model.raise_on_save_failure = true
+      DataMapper.setup(:default, (ENV["DATABASE_URL"] || "sqlite3:///#{Dir.pwd}/development.sqlite3"))
+      DataMapper.auto_upgrade!
+    end
   end
 
   include DataMapper::Resource

--- a/web.rb
+++ b/web.rb
@@ -17,10 +17,6 @@ class Web < Sinatra::Base
     enable :logging
   end
 
-  configure do
-    Character.dm_setup
-  end
-
   set :haml, format: :html5
 
   get '/' do

--- a/web.rb
+++ b/web.rb
@@ -63,6 +63,7 @@ class Web < Sinatra::Base
       haml :get_character_url
     rescue Exception => e
       c.destroy if c
+      logger.error "#{e.class}: #{e.message}"
       "Something went wrong: " + e.message
     end
   end

--- a/web.rb
+++ b/web.rb
@@ -2,7 +2,6 @@ require 'rubygems'
 require 'sinatra/base'
 require 'data_mapper'
 require 'active_support/multibyte/chars'
-require 'aws/s3'
 require 'haml'
 require 'maruku'
 require 'character'
@@ -23,15 +22,6 @@ class Web < Sinatra::Base
     DataMapper::Model.raise_on_save_failure = true
     DataMapper.setup(:default, (ENV["DATABASE_URL"] || "sqlite3:///#{Dir.pwd}/development.sqlite3"))
     DataMapper.auto_upgrade!
-
-    s3 = AWS::S3.new(
-      access_key_id:     ENV["AWS_ACCESS_KEY_ID"],
-      secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"])
-
-    bucket_name = "bestsigs-wow-cacher"
-    bucket_name += "-development" if development?
-
-    $bucket = s3.buckets[bucket_name]
   end
 
   set :haml, format: :html5

--- a/web.rb
+++ b/web.rb
@@ -17,6 +17,10 @@ class Web < Sinatra::Base
     enable :logging
   end
 
+  configure do
+    Character.dm_setup
+  end
+
   set :haml, format: :html5
 
   get '/' do

--- a/web.rb
+++ b/web.rb
@@ -1,6 +1,5 @@
 require 'rubygems'
 require 'sinatra/base'
-require 'data_mapper'
 require 'active_support/multibyte/chars'
 require 'haml'
 require 'maruku'
@@ -19,9 +18,7 @@ class Web < Sinatra::Base
   end
 
   configure do
-    DataMapper::Model.raise_on_save_failure = true
-    DataMapper.setup(:default, (ENV["DATABASE_URL"] || "sqlite3:///#{Dir.pwd}/development.sqlite3"))
-    DataMapper.auto_upgrade!
+    Character.dm_setup
   end
 
   set :haml, format: :html5


### PR DESCRIPTION
Do image updating when loading the image directly in a new thread, to avoid occasional spikes in response time. The request that triggers and update will serve the old image, but it should take no more time than any other request, and the next request will quickly return the updated image.
